### PR TITLE
I've added padding, so that toHex values are always 6 characters long.

### DIFF
--- a/Color.php
+++ b/Color.php
@@ -93,7 +93,7 @@ class Color
      */
     public function toHex()
     {
-        return dechex($this->color);
+        return str_pad(dechex($this->color),6,"0",STR_PAD_LEFT);
     }
     
     /**


### PR DESCRIPTION
This means values aren't too short for use in html and css.
